### PR TITLE
use base docker image (1.11.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwhisk/alarmprovider:1.10.4
+FROM openwhisk/alarmprovider:1.11.0
 
 COPY package.json /alarmsTrigger/
 RUN cd /alarmsTrigger && npm install --production


### PR DESCRIPTION
update to use latest docker image for https://github.com/apache/incubator-openwhisk-package-alarms