### PR TITLE
Make open timeout configurable

### DIFF
--- a/provider/lib/manager.js
+++ b/provider/lib/manager.js
@@ -47,6 +47,7 @@ module.exports = function (logger, triggerDB, redisClient, databaseName) {
     self.monitorStatus = {};
     self.retrying = {};
     self.databaseName = databaseName;
+    self.openTimeout = process.env.HTTP_OPEN_TIMEOUT_MS || 30000;
 
 
     function createTrigger(triggerIdentifier, newTrigger) {
@@ -689,7 +690,8 @@ module.exports = function (logger, triggerDB, redisClient, databaseName) {
         	var needleMethod = requestOptions.method; 
         	var needleUrl = requestOptions.uri;
         	var needleOptions = {
-                rejectUnauthorized: false
+                rejectUnauthorized: false,
+                open_timeout: self.openTimeout
             };
             if( requestOptions.auth.user ) {   //* cf-based authorization 
                 const usernamePassword = requestOptions.auth.user  +":"+ requestOptions.auth.pass;


### PR DESCRIPTION
make Needle's `open_timeout` configurable via env var `HTTP_OPEN_TIMEOUT_MS`, defaulting to 30 seconds, see https://github.com/tomas/needle/blob/f9d554e0ba1fc545fb406b6093b620bbab92c43c/README.md#request-options
