### PR TITLE
Fix long delay in trigger creation

### DIFF
--- a/provider/app.js
+++ b/provider/app.js
@@ -116,6 +116,7 @@ function createRedisClient() {
                 // This is a bogus message and should be fixed in a later release of the package.
             } else {
                 client = redis.createClient(redisUrl);
+                client.stream.setKeepAlive(true, 60000);  //** do keep-alive ping each min */
             }
 
             client.on('connect', function () {

--- a/provider/lib/cronAlarm.js
+++ b/provider/lib/cronAlarm.js
@@ -35,6 +35,8 @@ module.exports = function (logger, newTrigger) {
         monitor: newTrigger.monitor,
         additionalData: newTrigger.additionalData
     };
+    
+    this.cachedTrigger = cachedTrigger; 
 
     this.scheduleAlarm = function (triggerIdentifier, callback) {
         var method = 'scheduleCronAlarm';

--- a/provider/lib/dateAlarm.js
+++ b/provider/lib/dateAlarm.js
@@ -31,6 +31,7 @@ module.exports = function (logger, newTrigger) {
         monitor: newTrigger.monitor,
         additionalData: newTrigger.additionalData
     };
+    this.cachedTrigger = cachedTrigger; 
 
     this.scheduleAlarm = function (triggerIdentifier, callback) {
         var method = 'scheduleDateAlarm';

--- a/provider/lib/intervalAlarm.js
+++ b/provider/lib/intervalAlarm.js
@@ -32,6 +32,8 @@ module.exports = function (logger, newTrigger) {
         additionalData: newTrigger.additionalData
     };
 
+    this.cachedTrigger = cachedTrigger 
+
     this.scheduleAlarm = function (triggerIdentifier, callback) {
         var method = 'scheduleIntervalAlarm';
 

--- a/provider/lib/manager.js
+++ b/provider/lib/manager.js
@@ -630,7 +630,6 @@ module.exports = function (logger, triggerDB, redisClient, databaseName) {
                 
                 subscriber.on('connect', function () {
                     logger.info(method, 'Successfully connected or re-connected  the subscriber client to redis');
-                    subscriber.stream.setKeepAlive(true, 60000);  //** do keep-alive ping each min */
                 });
 
                 subscriber.on('error', function (err) {

--- a/provider/lib/manager.js
+++ b/provider/lib/manager.js
@@ -541,13 +541,19 @@ module.exports = function (logger, triggerDB, redisClient, databaseName) {
                     return scheduleTrigger(alarm,triggerIdentifier)
                 })
                 .then(cachedTrigger => {
-                    logger.info(method, triggerIdentifier, ': Trigger fired first time successfully');
+                    logger.info(method, triggerIdentifier, ': Trigger scheduled successfully');
 
                     if (isMonitoringTrigger(cachedTrigger.monitor, cachedTrigger.name)) {
                         self.monitorStatus.triggerStarted = "success";
                     }
 
+                    //****************************************************
+                    //* if the started trigger is an interval handle, then 
+                    //* do first fire immediately 
+                    //* all other kind of trigger - alarm events are called by callback
+                    //****************************************************
                     if (cachedTrigger.intervalHandle && shouldFireTrigger(cachedTrigger)) {
+                        logger.info(method, triggerIdentifier, ': Trigger fired first time successfully');
                         try {
                             var alarm_instance_id = "alarm_instance_id_"+ Date.now(); 
                             fireTrigger(cachedTrigger,alarm_instance_id);

--- a/provider/lib/manager.js
+++ b/provider/lib/manager.js
@@ -630,6 +630,7 @@ module.exports = function (logger, triggerDB, redisClient, databaseName) {
                 
                 subscriber.on('connect', function () {
                     logger.info(method, 'Successfully connected or re-connected  the subscriber client to redis');
+                    client.stream.setKeepAlive(true, 60000);  //** do keep-alive ping each min */
                 });
 
                 subscriber.on('error', function (err) {

--- a/provider/lib/manager.js
+++ b/provider/lib/manager.js
@@ -630,7 +630,7 @@ module.exports = function (logger, triggerDB, redisClient, databaseName) {
                 
                 subscriber.on('connect', function () {
                     logger.info(method, 'Successfully connected or re-connected  the subscriber client to redis');
-                    client.stream.setKeepAlive(true, 60000);  //** do keep-alive ping each min */
+                    subscriber.stream.setKeepAlive(true, 60000);  //** do keep-alive ping each min */
                 });
 
                 subscriber.on('error', function (err) {

--- a/provider/lib/manager.js
+++ b/provider/lib/manager.js
@@ -339,10 +339,10 @@ module.exports = function (logger, triggerDB, redisClient, databaseName) {
                     
                     if ( !err && body ) {
                         body.forEach(function (triggerConfig) {
-                            self.numOfConfiguredTriggers += 1; 
                             var triggerIdentifier = triggerConfig.id;
                             var doc = triggerConfig.doc;
                             if (!(triggerIdentifier in self.triggers) && !doc.monitor) {
+                                self.numOfConfiguredTriggers += 1;  //* num of customer triggers in config DB  
                                 //check if trigger still exists in whisk db
                                 var namespace = doc.namespace;
                                 var name = doc.name;

--- a/tools/travis/publish.sh
+++ b/tools/travis/publish.sh
@@ -7,7 +7,7 @@ dockerhub_image_name="$2"
 dockerhub_image_tag="$3"
 dockerhub_image="${CONTAINER_REGISTRY}/${dockerhub_image_prefix}/${dockerhub_image_name}:${dockerhub_image_tag}"
 
-# docker login is already done in jenkins job that calls this script
+# docker login is already done in jenkins job calling this script
 
 echo docker build . --tag ${dockerhub_image}
 docker build . --tag ${dockerhub_image}


### PR DESCRIPTION
List of fixes 
a) avoid redis clients reconnects every 10 min  ( even if running with 2 parallel running subscribers) 
b) split  create Alarm trigger  call in 2 calls . First create Alarm Type Obj and Secondly schedule the Alarm Type. --> better logging
c) Add logging of  "How many configured alarm triggers have to start,  how many  successfully started, and how many failed to start.   --> Error message if  less than 95% started .   
